### PR TITLE
Registered Artist model in admin site

### DIFF
--- a/site/spotifykloon/player/admin.py
+++ b/site/spotifykloon/player/admin.py
@@ -3,6 +3,6 @@ from django.contrib import admin
 from .models import Artist, Music, MusicTrack
 
 # Register your models here.
+admin.site.register(Artist)
 admin.site.register(Music)
 admin.site.register(MusicTrack)
-admin.site.register(Artist)


### PR DESCRIPTION
The Artist model was already registered in the admin site, however, it was placed after the other model registrations. It has been moved to precede other models for consistency and better readability.